### PR TITLE
fix(breadcrumb): make show name clickable only when not last item

### DIFF
--- a/script.js
+++ b/script.js
@@ -56,7 +56,7 @@ const updateBreadcrumb = (show = null, episode = null) => {
 
   breadcrumbContainer.style.display = "block";
 
-  // Add "Shows" item with proper event handling
+  // Always make "Shows" clickable as it's never the final item
   const showsItem = createBreadcrumbItem("Shows", () => {
     showSelector.value = ""; // Reset show selector
     showShowsListing();
@@ -67,15 +67,20 @@ const updateBreadcrumb = (show = null, episode = null) => {
   // Add separator
   breadcrumbList.appendChild(createSeparator());
 
-  // Add show name
-  const showItem = createBreadcrumbItem(show.name, () => {
-    if (currentShowId !== show.id) {
-      loadEpisodesForShow(show.id);
-    }
-    displayEpisodes(allEpisodes);
-    showSelector.value = show.id;
-    updateBreadcrumb(show); // Update breadcrumb without episode
-  });
+  // Add show name - only make it clickable if there's an episode selected
+  const showItem = createBreadcrumbItem(
+    show.name,
+    episode
+      ? () => {
+          if (currentShowId !== show.id) {
+            loadEpisodesForShow(show.id);
+          }
+          displayEpisodes(allEpisodes);
+          showSelector.value = show.id;
+          updateBreadcrumb(show); // Update breadcrumb without episode
+        }
+      : null
+  );
   breadcrumbList.appendChild(showItem);
 
   // Add episode if selected

--- a/style.css
+++ b/style.css
@@ -51,7 +51,6 @@ ul.breadcrumb li {
 ul.breadcrumb li span {
   color: #0275d8;
   text-decoration: none;
-  cursor: pointer;
 }
 ul.breadcrumb li span:hover {
   color: #01447e;


### PR DESCRIPTION
- Update updateBreadcrumb function to handle clickable states based on context
- Keep "Shows" always clickable as it's never the final item
- Make show name clickable only when viewing an episode
- Leave episode name always non-clickable as it's always the final item

This change improves navigation consistency by only making breadcrumb items clickable when they can take users "back" in the hierarchy. Previously, show names were always clickable even when they were the last item, which was inconsistent with breadcrumb patterns.

Test Case:
- When viewing show list: Shows
- When viewing show: Shows / Show Name (only "Shows" clickable)
- When viewing episode: Shows / Show Name / Episode (both "Shows" and "Show Name" clickable)

<!--

You must title your PR like this:

COHORT_NAME | FIRST_NAME LAST_NAME | REPO_NAME | WEEK

For example,

NW4 | Carol Owen | HTML-CSS-Module | Week1

Complete the task list below this message.
If your PR is rejected, check the task list.

-->

## Learners, PR Template

Self checklist

- [ ] I have committed my files one by one, on purpose, and for a reason
- [ ] I have titled my PR with COHORT_NAME | FIRST_NAME LAST_NAME | REPO_NAME | WEEK 
- [ ] I have tested my changes
- [ ] My changes follow the [style guide](https://syllabus.codeyourfuture.io/guides/code-style-guide/)
- [ ] My changes meet the [requirements](./README.md) of this task

## Changelist

Briefly explain your PR.

## Questions

Ask any questions you have for your reviewer.
