### PR TITLE
Prevent single card from stretching full width in grid layout

### DIFF
--- a/shows.css
+++ b/shows.css
@@ -5,6 +5,7 @@
   column-gap: 1rem;
 }
 .tv-show-card {
+  max-width: 300px;
   position: relative;
   break-inside: avoid;
   background: white;
@@ -199,11 +200,17 @@
 /* Responsive design */
 
 @media (max-width: 1200px) {
+  .tv-show-card {
+    max-width: 25rem;
+  }
   .tv-shows {
     columns: 3;
   }
 }
 @media (max-width: 900px) {
+  .tv-show-card {
+    max-width: 25rem;
+  }
   .tv-shows {
     columns: 2;
   }
@@ -227,6 +234,9 @@
 }
 
 @media (max-width: 600px) {
+  .tv-show-card {
+    max-width: 100%;
+  }
   .tv-shows {
     columns: 1;
   }
@@ -241,5 +251,10 @@
 
   .tv-show-title {
     font-size: 1.5rem;
+  }
+
+  .full-rating-container {
+    justify-content: start;
+    padding: 1rem 1rem 0.2rem;
   }
 }


### PR DESCRIPTION
- Added a media query to adjust the grid layout when there's only one card.
- Ensured the single card does not stretch too wide by limiting its max-width and centering it.

<!--

You must title your PR like this:

COHORT_NAME | FIRST_NAME LAST_NAME | REPO_NAME | WEEK

For example,

NW4 | Carol Owen | HTML-CSS-Module | Week1

Complete the task list below this message.
If your PR is rejected, check the task list.

-->

## Learners, PR Template

Self checklist

- [ ] I have committed my files one by one, on purpose, and for a reason
- [ ] I have titled my PR with COHORT_NAME | FIRST_NAME LAST_NAME | REPO_NAME | WEEK 
- [ ] I have tested my changes
- [ ] My changes follow the [style guide](https://syllabus.codeyourfuture.io/guides/code-style-guide/)
- [ ] My changes meet the [requirements](./README.md) of this task

## Changelist

Briefly explain your PR.

## Questions

Ask any questions you have for your reviewer.
